### PR TITLE
Fixes for dev version of stringr

### DIFF
--- a/R/tidy_formula.R
+++ b/R/tidy_formula.R
@@ -19,6 +19,8 @@
 f_charvec_to_formula <- function(lhs, rhs){
 
   if(rlang::is_empty(rhs)){return(NULL)} else{
+    rhs <- as.character(rhs)
+    lhs <- as.character(lhs)
 
     stringr::str_c(rhs, collapse = " + ") %>%
       stringr::str_c(lhs, " ~ ", ., collapse = "")  %>%
@@ -151,9 +153,6 @@ f_modify_formula <- function(f,
   if(length(rhs_remove) > 1){
     rhs_remove <- stringr::str_c(rhs_remove, collapse = "|")
   }
-
-
-
   f %>%
     f_formula_to_charvec() %>%
     stringr::str_subset(rhs_remove, negate = negate) %>%

--- a/R/tidy_predict.R
+++ b/R/tidy_predict.R
@@ -40,6 +40,7 @@ tidy_predict.Rcpp_ENSEMBLE <- function(model, newdata, form = NULL, ...){
 
   new_name <- form %>%
     rlang::f_lhs() %>%
+    as.character() %>%
     stringr::str_c("_preds_", model_name)
 
   newdata %>%
@@ -66,6 +67,7 @@ tidy_predict.glm <- function(model, newdata, form = NULL, ...){
 
   new_name <- form %>%
     rlang::f_lhs() %>%
+    as.character() %>%
     stringr::str_c("_preds_", model_name)
 
   newdata %>%
@@ -99,6 +101,7 @@ tidy_predict.default <- function(model, newdata, form = NULL, ...){
     rlang::f_lhs() -> target
 
   new_name <- target %>%
+    as.character() %>%
     stringr::str_c("_preds_", model_name)
 
   newdata %>%
@@ -128,6 +131,7 @@ tidy_predict.BinaryTree <- function(model, newdata, form = NULL, ...){
     rlang::f_lhs() -> target
 
   new_name <- target %>%
+    as.character() %>%
     stringr::str_c("_preds_", model_name)
 
   newdata %>%
@@ -174,6 +178,7 @@ tidy_predict.xgb.Booster <- function(model, newdata, form = NULL, olddata = NULL
   rlang::f_lhs() -> lhs1
 
  lhs1 %>%
+  as.character() %>%
   stringr::str_c("_preds_", model_name) -> new_name
 
 
@@ -181,7 +186,9 @@ tidy_predict.xgb.Booster <- function(model, newdata, form = NULL, olddata = NULL
 
 if(objective == "multi:softmax" ){
 
-  classpred_name <-  lhs1 %>% stringr::str_c("_preds_", "class_", model_name)
+  classpred_name <-  lhs1 %>%
+    as.character() %>%
+    stringr::str_c("_preds_", "class_", model_name)
 
 
   newdata %>%
@@ -225,14 +232,18 @@ if(objective == "multi:softmax" ){
       levels() -> class_levels
 
 
-    prob_pred_name <-  lhs1 %>% stringr::str_c("_preds_", "prob_", model_name)
+    prob_pred_name <-  lhs1 %>%
+      as.character() %>%
+      stringr::str_c("_preds_", "prob_", model_name)
 
 
     newdata %>%
       dplyr::mutate("{prob_pred_name}" := preds) -> newdata1
 
 
-    classpred_name <-  lhs1 %>% stringr::str_c("_preds_", "class_", model_name)
+    classpred_name <-  lhs1 %>%
+      as.character() %>%
+      stringr::str_c("_preds_", "class_", model_name)
 
 
 

--- a/R/tidy_shap.R
+++ b/R/tidy_shap.R
@@ -85,6 +85,7 @@ if(!is.null(aggregate)){
 
    new_name <- form %>%
      rlang::f_lhs() %>%
+     as.character() %>%
      stringr::str_c(" shaps from model ", model_name, " on dataset ", data_name)
 
  shaps +


### PR DESCRIPTION
stringr now requires that you give `str_c()` strings (or string like vectors), so passing in components of a formula no longer works.