### PR TITLE
load dplyr in vignette

### DIFF
--- a/vignettes/autostats.Rmd
+++ b/vignettes/autostats.Rmd
@@ -18,7 +18,7 @@ library(broom.mixed)
 
 ```{r setup}
 library(autostats)
-
+library(dplyr)
 ```
 
 ## plot variable contributions


### PR DESCRIPTION
In `tune` 2.0.0 (coming soon, within a week or so), we updated some of our re-exports. It looks like that broke one of the autostats vignettes that used `dplyr::filter()` without explicitly loading `dplyr`. 

This PR fixes that by... `load(dplyr)` after `autostats`. 